### PR TITLE
Fix the number of mnemonic to 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "breez-wasm-wallet",
+  "name": "wasm-example-app",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "breez-wasm-wallet",
+      "name": "wasm-example-app",
       "version": "0.1.0",
       "dependencies": {
         "@breeztech/breez-sdk-liquid": "^0.8.0",

--- a/src/pages/GeneratePage.tsx
+++ b/src/pages/GeneratePage.tsx
@@ -25,7 +25,7 @@ const GeneratePage: React.FC<GeneratePageProps> = ({
     const generateMnemonic = async () => {
       try {
         // Generate a random mnemonic (128-256 bits of entropy)
-        const newMnemonic = bip39.generateMnemonic(128); // 24 words
+        const newMnemonic = bip39.generateMnemonic(256); // 24 words
         setMnemonic(newMnemonic);
       } catch (error) {
         console.error('Failed to generate mnemonic:', error);


### PR DESCRIPTION
Changed the mnemonic to 24 characters to match the text. After setting it up locally, the `package-lock.json` showed a diff, so I pushed it together.